### PR TITLE
Set the Heroku host when necessary

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,6 +26,9 @@
     "SENDGRID_USERNAME": {
       "required": true
     },
+    "HEROKU_APP_NAME": {
+      "required": true
+    },
     "ENVIRONMENT": "review"
   },
   "formation": {

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,11 @@ module WittyCart
 
   class << self
     def canonical_host
-      ENV['CANONICAL_HOST'] || 'localhost:3000'
+      ENV['CANONICAL_HOST'] || heroku_host || 'localhost:3000'
+    end
+
+    def heroku_host
+      "#{ENV['HEROKU_APP_NAME']}.herokuapp.com" if ENV['HEROKU_APP_NAME'].present?
     end
 
     def host

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
     authentication:       :plain,
     user_name:            ENV['SENDGRID_USERNAME'],
     password:             ENV['SENDGRID_PASSWORD'],
-    domain:               'heroku.com',
+    domain:               WittyCart.canonical_host,
     enable_starttls_auto: true
   }
 


### PR DESCRIPTION
If `CANONICAL_HOST` has not been defined, and the `HEROKU_APP_NAME` has been defined, it generates the Heroku Review App Host.

This is necessary to send emails referring to the correct host, for instance. 🤘🏼